### PR TITLE
Kill the CMake Error -- clang/clang++  is not a full path and was not…

### DIFF
--- a/toolchain/iOS.cmake
+++ b/toolchain/iOS.cmake
@@ -47,8 +47,8 @@ endif (CMAKE_UNAME)
 
 # Force the compilers to gcc for iOS
 include (CMakeForceCompiler)
-CMAKE_FORCE_C_COMPILER (clang Apple)
-CMAKE_FORCE_CXX_COMPILER (clang++ Apple)
+CMAKE_FORCE_C_COMPILER (/usr/bin/gcc Apple)
+CMAKE_FORCE_CXX_COMPILER (/usr/bin/g++ Apple)
 set(CMAKE_AR ar CACHE FILEPATH "" FORCE)
 
 # Skip the platform compiler checks for cross compiling


### PR DESCRIPTION
… found in the PATH.

CMake Error at CMakeLists.txt:3 (project): 
The CMAKE_CXX_COMPILER: 

clang++ 

is not a full path and was not found in the PATH. 

Tell CMake where to find the compiler by setting either the environment 
variable "CXX" or the CMake cache entry CMAKE_CXX_COMPILER to the full path 
to the compiler, or to the compiler name if it is in the PATH. 

CMake Error at CMakeLists.txt:3 (project): 
The CMAKE_C_COMPILER: 

clang

is not a full path and was not found in the PATH. 

Tell CMake where to find the compiler by setting either the environment 
variable "CC" or the CMake cache entry CMAKE_C_COMPILER to the full path 
to the compiler, or to the compiler name if it is in the PATH.